### PR TITLE
Fixed Bash Sleep Command

### DIFF
--- a/power_api/power_api.py
+++ b/power_api/power_api.py
@@ -1048,7 +1048,7 @@ class SixfabPower:
 
             if result2 == Definition.SET_OK:
                 print("Raspberry Pi will shutdown in 5 seconds!")
-                os.system("sleep 5 & sudo shutdown -h now")
+                os.system("sleep 5 && sudo shutdown -h now")
                 return result2
 
         return Definition.SET_FAILED
@@ -1110,7 +1110,7 @@ class SixfabPower:
 
             if result2 == Definition.SET_OK:
                 print("Raspberry Pi will shutdown in 5 seconds!")
-                os.system("sleep 5 & sudo reboot")
+                os.system("sleep 5 && sudo reboot")
                 return result2
 
         return Definition.SET_FAILED


### PR DESCRIPTION
When you use single ampersand (&) to run multiple commands, bash/shell runs the commands in background. If you want to wait the first command to run second one, you should double ampersands (&&).

In this case, the API have to wait 5 seconds before cutting the power of pi. It cannot run sleep command in background/parallel. It must be sync.